### PR TITLE
Modify responses for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-scripts/*
+scripts
 jwtRS256.key
 jwtRS256.key.pub
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -13,6 +13,7 @@ from app.utilities.account_functions import \
     create_account, verify_account, change_password, \
     forgot_password, restore_forgotten_password
 from app.utilities.encryption import generate_oauth_token
+import time
 
 
 class Token(BaseModel):
@@ -35,8 +36,8 @@ def index_route():
     }
 
 
-@app.post("/login")
-async def login_route(
+@app.post("/login/form")
+async def login_form_route(
     email: str = Form(...),
     password: str = Form(...)
 ):
@@ -47,11 +48,26 @@ async def login_route(
     }
 
 
-@app.post("/refresh", response_model=Token)
-async def login_route(
+@app.post("/login/access")
+async def login_access_token_route(
+    access_token: str = Form(...)
+):
+    # Don't need to generate a new jwt when the access_token is still valid
+    account = await authenticate_from_access_token(access_token)
+    return {
+        "account": account
+    }
+
+
+@app.post("/login/refresh")
+async def login_refresh_token_route(
     refresh_token: str = Form(...)
 ):
-    return await authenticate_from_refresh_token(refresh_token)
+    account = await authenticate_from_refresh_token(refresh_token)
+    return {
+        "jwt": generate_oauth_token(account),
+        "account": account
+    }
 
 
 @app.post('/register')

--- a/app/routes.py
+++ b/app/routes.py
@@ -9,9 +9,9 @@ from app import app, ENVIRONMENT, PUBLIC_KEY, oauth2_scheme
 from app.utilities.authentication import \
     authenticate_from_login, authenticate_from_access_token, \
     authenticate_from_refresh_token
-from app.utilities.account_functions import \
-    create_account, verify_account, change_password, \
-    forgot_password, restore_forgotten_password
+from app.utilities.account_functions import change_password, \
+    create_account, forgot_password, resend_verification, \
+    restore_forgotten_password, verify_account
 from app.utilities.encryption import generate_oauth_token
 import time
 
@@ -128,3 +128,11 @@ async def change_password_route(
         "jwt": generate_oauth_token(account),
         "account": account
     }
+
+
+@app.post('/resend-verification')
+async def change_password_route(
+    email: str = Form(...),
+):
+    await resend_verification(email)
+    return {"status": "success"}

--- a/app/routes.py
+++ b/app/routes.py
@@ -12,6 +12,7 @@ from app.utilities.authentication import \
 from app.utilities.account_functions import \
     create_account, verify_account, change_password, \
     forgot_password, restore_forgotten_password
+from app.utilities.encryption import generate_oauth_token
 
 
 class Token(BaseModel):
@@ -34,12 +35,16 @@ def index_route():
     }
 
 
-@app.post("/login", response_model=Token)
+@app.post("/login")
 async def login_route(
     email: str = Form(...),
     password: str = Form(...)
 ):
-    return await authenticate_from_login(email, password)
+    account = await authenticate_from_login(email, password)
+    return {
+        "jwt": generate_oauth_token(account),
+        "account": account
+    }
 
 
 @app.post("/refresh", response_model=Token)
@@ -49,12 +54,16 @@ async def login_route(
     return await authenticate_from_refresh_token(refresh_token)
 
 
-@app.post('/register', response_model=Token)
+@app.post('/register')
 async def register_route(
     email: str = Form(...),
     password: str = Form(...)
 ):
-    return await create_account(email, password)
+    account = await create_account(email, password)
+    return {
+        "jwt": generate_oauth_token(account),
+        "account": account
+    }
 
 
 @app.post('/verify')

--- a/app/routes.py
+++ b/app/routes.py
@@ -87,7 +87,11 @@ async def verify_route(
     email_token: str = Form(...),
     password: str = Form(...)
 ):
-    return await verify_account(email_token, password)
+    account = await verify_account(email_token, password)
+    return {
+        "jwt": generate_oauth_token(account),
+        "account": account
+    }
 
 
 @app.get("/account", response_model=Account)

--- a/app/routes.py
+++ b/app/routes.py
@@ -111,16 +111,20 @@ async def change_password_route(
     return await change_password(account, old_password, new_password)
 
 
-@app.post('/forgot-password')
+@app.post('/request-new-password')
 async def change_password_route(
     email: str = Form(...)
 ):
     return await forgot_password(email)
 
 
-@app.post('/restore-forgotten-password')
+@app.post('/set-new-password')
 async def change_password_route(
-    forgot_password_token: str = Form(...),
-    new_password: str = Form(...)
+    password_token: str = Form(...),
+    password: str = Form(...)
 ):
-    return await restore_forgotten_password(forgot_password_token, new_password)
+    account = await restore_forgotten_password(password_token, password)
+    return {
+        "jwt": generate_oauth_token(account),
+        "account": account
+    }

--- a/app/utilities/account_functions.py
+++ b/app/utilities/account_functions.py
@@ -67,7 +67,7 @@ async def verify_account(email_token: str, password: str):
         )
         return {
             "email": account["email"],
-            "email_verified": account["email_verified"]
+            "email_verified": True
         }
     except Exception:
         raise HTTPException(
@@ -115,7 +115,7 @@ async def forgot_password(email: str):
     await account_collection.update_one(
         {"email": email},
         {"$set": {
-            "forgot_password_token": token,
+            "password_token": token,
         }}
     )
 
@@ -130,7 +130,7 @@ async def forgot_password(email: str):
     return {"status": "success"}
 
 
-async def restore_forgotten_password(forgot_password_token, new_password):
+async def restore_forgotten_password(password_token, new_password):
 
     if not validate_password_format(new_password):
         raise HTTPException(
@@ -139,20 +139,20 @@ async def restore_forgotten_password(forgot_password_token, new_password):
         )
 
     account = await account_collection.find_one(
-        {"forgot_password_token": forgot_password_token},
+        {"password_token": password_token},
         {"_id": 0, "email": 1, "email_verified": 1}
     )
 
     if account is None:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="forgot_password_token invalid",
+            detail="password_token invalid",
         )
 
     await account_collection.update_one(
-        {"forgot_password_token": forgot_password_token},
+        {"password_token": password_token},
         {'$set': {'hashed_password': generate_password_hash(new_password)},
-         '$unset': {'forgot_password_token': 1}}
+         '$unset': {'password_token': 1}}
     )
     return account
 

--- a/app/utilities/account_functions.py
+++ b/app/utilities/account_functions.py
@@ -51,7 +51,7 @@ async def create_account(email: str, password: str):
             detail=f"verification email could not be sent",
         )
 
-    return generate_oauth_token({"email": email, "email_verified": False})
+    return {"email": email, "email_verified": False}
 
 
 async def verify_account(email_token: str, password: str):

--- a/app/utilities/account_functions.py
+++ b/app/utilities/account_functions.py
@@ -155,3 +155,16 @@ async def restore_forgotten_password(forgot_password_token, new_password):
          '$unset': {'forgot_password_token': 1}}
     )
     return account
+
+
+async def resend_verification(email):
+    account = await account_collection.find_one({"email": email})
+
+    if account is not None:
+        try:
+            await send_verification_mail(account)
+        except Exception:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="email could not be sent"
+            )

--- a/app/utilities/account_functions.py
+++ b/app/utilities/account_functions.py
@@ -27,7 +27,7 @@ async def create_account(email: str, password: str):
     account_model = {
         "email": email,
         "hashed_password": generate_password_hash(password),
-        "email_token": generate_secret_token(length=32),
+        "email_token": generate_secret_token(length=20),
         "email_verified": False
     }
 
@@ -57,8 +57,7 @@ async def create_account(email: str, password: str):
 async def verify_account(email_token: str, password: str):
     try:
         account = await account_collection.find_one(
-            {"email_token": email_token},
-            {"_id": 0, "hashed_password": 1}
+            {"email_token": email_token}
         )
         assert(account is not None)
         assert(check_password_hash(password, account["hashed_password"]))
@@ -66,10 +65,13 @@ async def verify_account(email_token: str, password: str):
             {"email_token": email_token},
             {'$set': {'email_verified': True}}
         )
-        return {"status": "success"}
+        return {
+            "email": account["email"],
+            "email_verified": account["email_verified"]
+        }
     except Exception:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
+            status_code=status.HTTP_401_UNAUTHORIZED,
             detail="email_token or password invalid",
         )
 

--- a/app/utilities/account_functions.py
+++ b/app/utilities/account_functions.py
@@ -119,13 +119,8 @@ async def forgot_password(email: str):
         }}
     )
 
-    try:
-        await send_forgot_password_mail(email, token)
-    except Exception:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="email could not be sent"
-        )
+    # 500 error if email cannot be sent
+    await send_forgot_password_mail(email, token)
 
     return {"status": "success"}
 
@@ -161,10 +156,5 @@ async def resend_verification(email):
     account = await account_collection.find_one({"email": email})
 
     if account is not None:
-        try:
-            await send_verification_mail(account)
-        except Exception:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail="email could not be sent"
-            )
+        # 500 error if email cannot be sent
+        await send_verification_mail(account)

--- a/app/utilities/authentication.py
+++ b/app/utilities/authentication.py
@@ -45,7 +45,7 @@ async def authenticate_from_refresh_token(refresh_token: str):
     try:
         payload = check_jwt(refresh_token)
         account = await get_account(email=payload["email"])
-        assert(account is not None)
+        assert(account is not None)  # error if account has been deleted since then
         return account
     except (AssertionError, Exception):
         raise HTTPException(

--- a/app/utilities/authentication.py
+++ b/app/utilities/authentication.py
@@ -46,7 +46,7 @@ async def authenticate_from_refresh_token(refresh_token: str):
         payload = check_jwt(refresh_token)
         account = await get_account(email=payload["email"])
         assert(account is not None)
-        return generate_oauth_token(account)
+        return account
     except (AssertionError, Exception):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/app/utilities/authentication.py
+++ b/app/utilities/authentication.py
@@ -20,7 +20,7 @@ async def authenticate_from_login(
         account = await account_collection.find_one({"email": email})
         assert(account is not None)
         assert(check_password_hash(password, account["hashed_password"]))
-        return generate_oauth_token(account)
+        return {"email": account["email"], "email_verified": account["email_verified"]}
     except AssertionError:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/app/utilities/encryption.py
+++ b/app/utilities/encryption.py
@@ -73,14 +73,6 @@ def check_jwt(token):
 
 
 def validate_password_format(password: str):
-    try:
-        assert(8 <= len(password))
-        assert(len(password) <= 32)
-        assert(any([c.isnumeric() for c in password]))
-        assert(any([c.isalpha() for c in password]))
-        assert(any([not (c.isnumeric() or c.isalpha()) for c in password]))
-        return True
-    except AssertionError:
-        return False
+    return 8 <= len(password) <= 32
 
 # Validating the Email format here is useless ;)

--- a/app/utilities/mailing.py
+++ b/app/utilities/mailing.py
@@ -24,7 +24,7 @@ async def send_verification_mail(db_account):
 def verification_email_html(db_account):
     assert("email_token" in db_account)
     verification_url = (
-        ADMIN_FRONTEND_URL + "/verify-email?token=" + db_account["email_token"]
+        ADMIN_FRONTEND_URL + "/verify?email_token=" + db_account["email_token"]
     )
     return (
         '<h1>Welcome to FastSurvey!</h1>' +

--- a/app/utilities/mailing.py
+++ b/app/utilities/mailing.py
@@ -24,7 +24,7 @@ async def send_verification_mail(db_account):
 def verification_email_html(db_account):
     assert("email_token" in db_account)
     verification_url = (
-        ADMIN_FRONTEND_URL + "/verify?email_token=" + db_account["email_token"]
+        ADMIN_FRONTEND_URL + "/verify?token=" + db_account["email_token"]
     )
     return (
         '<h1>Welcome to FastSurvey!</h1>' +
@@ -48,7 +48,7 @@ async def send_forgot_password_mail(email: str, token: str):
 
 def forgot_password_email_html(token: str):
     verification_url = (
-        ADMIN_FRONTEND_URL + "/forgot-password?token=" + token
+        ADMIN_FRONTEND_URL + "/set-password?token=" + token
     )
     return (
         '<h1>Restore your FastSurvey account</h1>' +

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,4 +42,6 @@ def assert_jwt_account_response(content_dict):
                 ["access_token", "refresh_token", "token_type"]]))
 
 
-TEST_EMAIL_DOMAIN = "@testing.fastsurvey.io"
+def email_account(n: int):
+    assert(n > 0)
+    return f"test+{n}@fastsurvey.io"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,4 +35,11 @@ def get_content_dict(response):
     return content_dict
 
 
+def assert_jwt_account_response(content_dict):
+    assert(all([key in content_dict for key in
+                ["jwt", "account"]]))
+    assert(all([key in content_dict["jwt"] for key in
+                ["access_token", "refresh_token", "token_type"]]))
+
+
 TEST_EMAIL_DOMAIN = "@testing.fastsurvey.io"

--- a/tests/test_change_password.py
+++ b/tests/test_change_password.py
@@ -8,10 +8,10 @@ MODIFIED_TEST_ACCOUNT = {"email": "e" + TEST_EMAIL_DOMAIN, "password": "123456a!
 
 
 def login(client, data, status_code):
-    response = client.post("/login", data=data)
+    response = client.post("/login/form", data=data)
     assert(response.status_code == status_code)
     if status_code == 200:
-        return get_content_dict(response)["access_token"]
+        return get_content_dict(response)["jwt"]["access_token"]
 
 
 def change_password(

--- a/tests/test_change_password.py
+++ b/tests/test_change_password.py
@@ -1,10 +1,10 @@
 
 from symbol import and_test
 
-from tests.conftest import TEST_EMAIL_DOMAIN, get_content_dict
+from tests.conftest import email_account, get_content_dict
 
-TEST_ACCOUNT = {"email": "e" + TEST_EMAIL_DOMAIN, "password": "123456a!"}
-MODIFIED_TEST_ACCOUNT = {"email": "e" + TEST_EMAIL_DOMAIN, "password": "123456a!!!"}
+TEST_ACCOUNT = {"email": email_account(10), "password": "123456a!"}
+MODIFIED_TEST_ACCOUNT = {"email": email_account(10), "password": "123456a!!!"}
 
 
 def login(client, data, status_code):

--- a/tests/test_forgot_password.py
+++ b/tests/test_forgot_password.py
@@ -8,16 +8,16 @@ MODIFIED_TEST_ACCOUNT = {"email": "f" + TEST_EMAIL_DOMAIN, "password": "123456a!
 
 
 def login(client, data, status_code):
-    response = client.post("/login", data=data)
+    response = client.post("/login/form", data=data)
     assert(response.status_code == status_code)
 
 
 def restore_forgotten_password(
-    client, forgot_password_token, new_password, status_code
+    client, password_token, password, status_code
 ):
-    response = client.post("/restore-forgotten-password", data={
-        "forgot_password_token": forgot_password_token,
-        "new_password": new_password,
+    response = client.post("/set-new-password", data={
+        "password_token": password_token,
+        "password": password,
     })
     assert(response.status_code == status_code)
 
@@ -39,7 +39,7 @@ def test_login(client, account_collection):
     # Login with registered account
     login(client, TEST_ACCOUNT, 200)
 
-    response = client.post("/forgot-password", data={
+    response = client.post("/request-new-password", data={
         "email": TEST_ACCOUNT["email"]
     })
     assert(response.status_code == 200)
@@ -47,24 +47,24 @@ def test_login(client, account_collection):
     # Login with current account still works
     login(client, TEST_ACCOUNT, 200)
 
-    forgot_password_token = account(account_collection)["forgot_password_token"]
+    password_token = account(account_collection)["password_token"]
 
     for test in [
         {
-            "forgot_password_token": "123",
-            "new_password": "123",
+            "password_token": "123",
+            "password": "123",
             "status_code": 400
         }, {
-            "forgot_password_token": "123",
-            "new_password": MODIFIED_TEST_ACCOUNT["password"],
+            "password_token": "123",
+            "password": MODIFIED_TEST_ACCOUNT["password"],
+            "status_code": 401
+        }, {
+            "password_token": password_token,
+            "password": "123",
             "status_code": 400
         }, {
-            "forgot_password_token": forgot_password_token,
-            "new_password": "123",
-            "status_code": 400
-        }, {
-            "forgot_password_token": forgot_password_token,
-            "new_password": MODIFIED_TEST_ACCOUNT["password"],
+            "password_token": password_token,
+            "password": MODIFIED_TEST_ACCOUNT["password"],
             "status_code": 200
         }
     ]:
@@ -73,4 +73,4 @@ def test_login(client, account_collection):
     login(client, TEST_ACCOUNT, 401)
     login(client, MODIFIED_TEST_ACCOUNT, 200)
 
-    assert("forgot_password_token" not in account(account_collection))
+    assert("password_token" not in account(account_collection))

--- a/tests/test_forgot_password.py
+++ b/tests/test_forgot_password.py
@@ -1,10 +1,10 @@
 
 from symbol import and_test
 
-from tests.conftest import TEST_EMAIL_DOMAIN, get_content_dict
+from tests.conftest import email_account, get_content_dict
 
-TEST_ACCOUNT = {"email": "f" + TEST_EMAIL_DOMAIN, "password": "123456a!"}
-MODIFIED_TEST_ACCOUNT = {"email": "f" + TEST_EMAIL_DOMAIN, "password": "123456a!!!"}
+TEST_ACCOUNT = {"email": email_account(30), "password": "123456a!"}
+MODIFIED_TEST_ACCOUNT = {"email": email_account(30), "password": "123456a!!!"}
 
 
 def login(client, data, status_code):

--- a/tests/test_forgot_password.py
+++ b/tests/test_forgot_password.py
@@ -73,4 +73,6 @@ def test_login(client, account_collection):
     login(client, TEST_ACCOUNT, 401)
     login(client, MODIFIED_TEST_ACCOUNT, 200)
 
-    assert("password_token" not in account(account_collection))
+    db_account = account(account_collection)
+    print("--> account", db_account)
+    assert("password_token" not in db_account)

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,9 +1,9 @@
 
-from tests.conftest import get_content_dict, TEST_EMAIL_DOMAIN, \
+from tests.conftest import get_content_dict, email_account, \
     assert_jwt_account_response
 
 
-TEST_ACCOUNT = {"email": "c" + TEST_EMAIL_DOMAIN, "password": "000000d!"}
+TEST_ACCOUNT = {"email": email_account(40), "password": "000000d!"}
 
 
 def test_login(client):

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,5 +1,6 @@
 
-from tests.conftest import get_content_dict, TEST_EMAIL_DOMAIN
+from tests.conftest import get_content_dict, TEST_EMAIL_DOMAIN, \
+    assert_jwt_account_response
 
 
 TEST_ACCOUNT = {"email": "c" + TEST_EMAIL_DOMAIN, "password": "000000d!"}
@@ -7,7 +8,7 @@ TEST_ACCOUNT = {"email": "c" + TEST_EMAIL_DOMAIN, "password": "000000d!"}
 
 def test_login(client):
     # Login with not-registered account
-    response = client.post("/login", data=TEST_ACCOUNT)
+    response = client.post("/login/form", data=TEST_ACCOUNT)
     assert(response.status_code == 401)
 
     # Registered that account
@@ -15,14 +16,12 @@ def test_login(client):
     assert(response.status_code == 200)
 
     # Login with registered account
-    response = client.post("/login", data=TEST_ACCOUNT)
+    response = client.post("/login/form", data=TEST_ACCOUNT)
     assert(response.status_code == 200)
 
     # Check whether response has the right format
     content_dict = get_content_dict(response)
-    assert(all([key in content_dict for key in
-                ["access_token", "refresh_token", "token_type"]]))
-    assert(content_dict["token_type"] == "bearer")
+    assert_jwt_account_response(content_dict)
 
     # Try to get private data with invalid access_token
     response = client.get("/account", headers={
@@ -32,7 +31,7 @@ def test_login(client):
 
     # Try to get private data with valid access_token
     response = client.get("/account", headers={
-        "Authorization": "bearer " + content_dict["access_token"]
+        "Authorization": "bearer " + content_dict["jwt"]["access_token"]
     })
     assert(response.status_code == 200)
     content_dict = get_content_dict(response)

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -23,6 +23,13 @@ def test_login(client):
     content_dict = get_content_dict(response)
     assert_jwt_account_response(content_dict)
 
+    # Access token refresh works
+    response = client.post("/login/access", data={
+        "access_token": content_dict["jwt"]["access_token"]
+    })
+    assert(response.status_code == 200)
+    assert("account" in get_content_dict(response))
+
     # Try to get private data with invalid access_token
     response = client.get("/account", headers={
         "Authorization": "bearer 123"

--- a/tests/test_refresh_token.py
+++ b/tests/test_refresh_token.py
@@ -1,9 +1,9 @@
 
-from tests.conftest import get_content_dict, TEST_EMAIL_DOMAIN, \
+from tests.conftest import get_content_dict, email_account, \
     assert_jwt_account_response
 
 
-TEST_ACCOUNT = {"email": "g" + TEST_EMAIL_DOMAIN, "password": "000abcd!"}
+TEST_ACCOUNT = {"email": email_account(50), "password": "000abcd!"}
 
 
 def get_account(client, access_token, status_code):

--- a/tests/test_refresh_token.py
+++ b/tests/test_refresh_token.py
@@ -1,13 +1,21 @@
 
-from tests.conftest import get_content_dict, TEST_EMAIL_DOMAIN
+from tests.conftest import get_content_dict, TEST_EMAIL_DOMAIN, \
+    assert_jwt_account_response
 
 
 TEST_ACCOUNT = {"email": "g" + TEST_EMAIL_DOMAIN, "password": "000abcd!"}
 
 
+def get_account(client, access_token, status_code):
+    response = client.get("/account", headers={
+        "Authorization": "bearer " + access_token
+    })
+    assert(response.status_code == status_code)
+
+
 def test_refresh_token(client):
     # Login with not-registered account
-    response = client.post("/login", data=TEST_ACCOUNT)
+    response = client.post("/login/form", data=TEST_ACCOUNT)
     assert(response.status_code == 401)
 
     # Registered that account
@@ -15,40 +23,26 @@ def test_refresh_token(client):
     assert(response.status_code == 200)
 
     # Login with registered account
-    response = client.post("/login", data=TEST_ACCOUNT)
+    response = client.post("/login/form", data=TEST_ACCOUNT)
     assert(response.status_code == 200)
 
     # Check whether response has the right format
     content_dict = get_content_dict(response)
-    assert(all([key in content_dict for key in [
-        "access_token", "refresh_token", "token_type"]
-    ]))
-    access_token_1 = content_dict["access_token"]
-    refresh_token_1 = content_dict["refresh_token"]
+    access_token_1 = content_dict["jwt"]["access_token"]
+    refresh_token_1 = content_dict["jwt"]["refresh_token"]
 
     # Try to get private data with valid access_token
-    response = client.get("/account", headers={
-        "Authorization": "bearer " + access_token_1
-    })
-    assert(response.status_code == 200)
+    get_account(client, access_token_1, 200)
 
     # Try to get private data with valid access_token
-    response = client.post("/refresh", data={
+    response = client.post("/login/refresh", data={
         "refresh_token": refresh_token_1
     })
     assert(response.status_code == 200)
     content_dict = get_content_dict(response)
-    assert(all([key in content_dict for key in [
-        "access_token", "refresh_token", "token_type"]
-    ]))
-    access_token_2 = content_dict["access_token"]
+    assert_jwt_account_response(content_dict)
+    access_token_2 = content_dict["jwt"]["access_token"]
 
     # Both access tokens work now!
-    response = client.get("/account", headers={
-        "Authorization": "bearer " + access_token_1
-    })
-    assert(response.status_code == 200)
-    response = client.get("/account", headers={
-        "Authorization": "bearer " + access_token_2
-    })
-    assert(response.status_code == 200)
+    get_account(client, access_token_1, 200)
+    get_account(client, access_token_2, 200)

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -9,7 +9,7 @@ TEST_SET_1 = [
         "data": {"email": "a", "password": "000000a!"},
         "result": False  # Invalid email format
     }, {
-        "data": {"email": "a" + TEST_EMAIL_DOMAIN, "password": "000000aa"},
+        "data": {"email": "a" + TEST_EMAIL_DOMAIN, "password": "000000"},
         "result": False  # Invalid password format
     }, {
         "data": {"email": "a" + TEST_EMAIL_DOMAIN, "password": "000000a!"},

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -2,27 +2,27 @@
 import json
 import os
 import time
-from tests.conftest import TEST_EMAIL_DOMAIN
+from tests.conftest import email_account
 
 TEST_SET_1 = [
     {
-        "data": {"email": "a", "password": "000000a!"},
+        "data": {"email": "60", "password": "000000a!"},
         "result": False  # Invalid email format
     }, {
-        "data": {"email": "a" + TEST_EMAIL_DOMAIN, "password": "000000"},
+        "data": {"email": email_account(60), "password": "000000"},
         "result": False  # Invalid password format
     }, {
-        "data": {"email": "a" + TEST_EMAIL_DOMAIN, "password": "000000a!"},
+        "data": {"email": email_account(60), "password": "000000a!"},
         "result": True
     }, {
-        "data": {"email": "a" + TEST_EMAIL_DOMAIN, "password": "000000b!"},
+        "data": {"email": email_account(60), "password": "000000b!"},
         "result": False  # Email already taken
     }, {
-        "data": {"email": "b" + TEST_EMAIL_DOMAIN, "password": "000000c!"},
+        "data": {"email": email_account(61), "password": "000000c!"},
         "result": True
     }, {
-        "data": {"email": "b" + TEST_EMAIL_DOMAIN, "password": "000000d!"},
-        "result": False
+        "data": {"email": email_account(61), "password": "000000d!"},
+        "result": False  # Email already taken
     },
 ]
 

--- a/tests/test_resend_verification.py
+++ b/tests/test_resend_verification.py
@@ -1,0 +1,23 @@
+
+from symbol import and_test
+
+from tests.conftest import TEST_EMAIL_DOMAIN, get_content_dict
+
+INVALID_TEST_ACCOUNT = {"email": "h"}
+VALID_TEST_ACCOUNT = {"email": "h" + TEST_EMAIL_DOMAIN}
+REGISTERED_TEST_ACCOUNT = {"email": "i" + TEST_EMAIL_DOMAIN, "password": "123456789"}
+
+
+def resend_verification(client, data, status_code):
+    response = client.post("/resend-verification", data=data)
+    assert(response.status_code == status_code)
+
+
+def test_resend_verification(client):
+    resend_verification(client, INVALID_TEST_ACCOUNT, 200)
+    resend_verification(client, VALID_TEST_ACCOUNT, 200)
+
+    response = client.post("/register", data=REGISTERED_TEST_ACCOUNT)
+    assert(response.status_code == 200)
+
+    resend_verification(client, {"email": REGISTERED_TEST_ACCOUNT["email"]}, 200)

--- a/tests/test_resend_verification.py
+++ b/tests/test_resend_verification.py
@@ -1,11 +1,11 @@
 
 from symbol import and_test
 
-from tests.conftest import TEST_EMAIL_DOMAIN, get_content_dict
+from tests.conftest import email_account, get_content_dict
 
-INVALID_TEST_ACCOUNT = {"email": "h"}
-VALID_TEST_ACCOUNT = {"email": "h" + TEST_EMAIL_DOMAIN}
-REGISTERED_TEST_ACCOUNT = {"email": "i" + TEST_EMAIL_DOMAIN, "password": "123456789"}
+INVALID_TEST_ACCOUNT = {"email": "70"}
+VALID_TEST_ACCOUNT = {"email": email_account(70)}
+REGISTERED_TEST_ACCOUNT = {"email": email_account(71), "password": "123456789"}
 
 
 def resend_verification(client, data, status_code):

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -3,13 +3,6 @@ from app.utilities.encryption import validate_password_format
 
 TEST_SET = [
     {"password": "abc", "result": False},
-    {"password": "abcabcab", "result": False},
-    {"password": "12312312", "result": False},
-    {"password": "!?!?!?!?", "result": False},
-    {"password": "abc123ab", "result": False},
-    {"password": "abc!?!ab", "result": False},
-    {"password": "123!?!12", "result": False},
-    {"password": "000000a!", "result": True},
     {"password": "sdasds8!sdasds8!sdasds8!sdasds8!", "result": True},
     {"password": "sdasds8!sdasds8!sdasds8!sdasds8!a", "result": False}
 ]

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -1,7 +1,7 @@
 
-from tests.conftest import get_content_dict, TEST_EMAIL_DOMAIN
+from tests.conftest import get_content_dict, email_account
 
-TEST_ACCOUNT = {"email": "d" + TEST_EMAIL_DOMAIN, "password": "000000fg!"}
+TEST_ACCOUNT = {"email": email_account(90), "password": "000000fg!"}
 
 
 def verify_response(client, email_token, password):

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -29,14 +29,14 @@ def test_verification(client, account_collection):
     response = verify_response(
         client, account_in_db["email_token"], "123"
     )
-    assert(response.status_code == 400)
+    assert(response.status_code == 401)
     assert(account(account_collection)["email_verified"] == False)
 
     # Submit incorrect token
     response = verify_response(
         client, "123", TEST_ACCOUNT["password"]
     )
-    assert(response.status_code == 400)
+    assert(response.status_code == 401)
     assert(account(account_collection)["email_verified"] == False)
 
     # Submit correct token and password


### PR DESCRIPTION
Adjusted the responses for existing routes to be more unified and useful for the frontend.

Split up routes `/login` and `/refresh` to `/login/form`, `/login/access` and `/login/refresh`

Added route to resend the verification mail.

Added tests for all these things.